### PR TITLE
SCRUM-65 added essential yml configurations for lando

### DIFF
--- a/Backend/.lando.yml
+++ b/Backend/.lando.yml
@@ -2,3 +2,26 @@ name: druidpartneringapp
 recipe: drupal11
 config:
   webroot: web
+
+services:
+  appserver:
+    type: php:8.1
+    xdebug: true
+
+  database:
+    type: mariadb:10.4
+    portforward: 3306
+
+  mautic:
+    type: php:8.1
+    webroot: mautic
+
+  mailhog:
+    type: mailhog
+    portforward: 8025
+
+proxy:
+  appserver:
+    - drupal.lndo.site
+  mautic:
+    - mautic.lndo.site


### PR DESCRIPTION
## Related ticket:
[Ticket Jira SCRUM-65](https://druidpartneringproject2024bch.atlassian.net/browse/SCRUM-65)

## In this PR:
Setup for essential lando configurations in .yml file. 

## Yml config includes:

- Drupal and Mautic Services: With both Drupal (using drupal11) and Mautic on the same server.

- Database: Uses MariaDB with port forwarding for external access if needed.

- Mailhog: Provides email testing capability.

- Proxy Settings: Sets separate URLs for Drupal (drupal.lndo.site) and Mautic (mautic.lndo.site).

- PHP Version and xDebug: Runs PHP 8.1 with xDebug for debugging.
