### PR TITLE
SCRUM-119 Fix: Add redirect rule in netlify.toml to fix crash on refr…

### DIFF
--- a/Frontend/netlify.toml
+++ b/Frontend/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
## Related ticket:
[SCRUM-119](https://druidpartneringproject2024bch.atlassian.net/browse/SCRUM-119?atlOrigin=eyJpIjoiZGQ0NDlmNDMxODlhNGZlZDhiOGYyNjQyMzNlMGQxMTgiLCJwIjoiaiJ9)

## In this PR:
- Fix site crashing when refreshed on production build

## Testing instruction
- Don't test this branch, this fix only works on the production build
- Test this one instead `https://druid-project.alextran.dev/` I already apply the fix there.
- Just go to any page that is not the root URL and refresh the page.

[SCRUM-119]: https://druidpartneringproject2024bch.atlassian.net/browse/SCRUM-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ