### PR TITLE
HOTFIX-1 Fix: add prevent default to mautic form element

### DIFF
--- a/Frontend/src/components/ContactForm.tsx
+++ b/Frontend/src/components/ContactForm.tsx
@@ -59,6 +59,8 @@ export default function ContactForm() {
           id="mauticform_contactformclient"
           data-mautic-form="contactformclient"
           encType="multipart/form-data"
+          // prevent redirect to Mautic url and show 403 error
+          onSubmit={e => e.preventDefault()}
         >
           <div
             className="mauticform-error"


### PR DESCRIPTION
## Related ticket:
Hotfix, no ticket

## In this PR:
- Fix mautic form 403 error when submit

## Testing instruction
- Checkout Contact page
- Submit the form
- It should not redirect you anywhere and show error, instead show a thank you msg
- Go to frontpage and wait 1-3 seconds and then refresh to see personalised contents
- Go back to the contact page and you will be a different personalised msg